### PR TITLE
Move site:new on drupal-console-launcher project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
     "require": {
         "php": "^5.5.9 || ^7.0",
         "drupal/console-core" : "~1.0",
-        "padraic/phar-updater": "~1.0@dev"
+        "padraic/phar-updater": "~1.0@dev",
+        "symfony/dom-crawler": "~2.7|~2.8",
+        "guzzlehttp/guzzle": "~6.1",
+        "alchemy/zippy": "0.3.5"
     },
     "bin": ["bin/drupal"],
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f03fc8edddafc7dc02a17d55c9ca9dfa",
-    "content-hash": "8e3037ef0482a7901ef99838cc366e23",
+    "hash": "cab5c3488944cc2463051bdf86d0b529",
+    "content-hash": "b1c6c310a149b66e7a2da88ec63604e5",
     "packages": [
+        {
+            "name": "alchemy/zippy",
+            "version": "0.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alchemy-fr/Zippy.git",
+                "reference": "92c773f7bbe47fdb30c61dbaea3dcbf4dd13a40a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alchemy-fr/Zippy/zipball/92c773f7bbe47fdb30c61dbaea3dcbf4dd13a40a",
+                "reference": "92c773f7bbe47fdb30c61dbaea3dcbf4dd13a40a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/collections": "~1.0",
+                "ext-mbstring": "*",
+                "php": ">=5.3.3",
+                "symfony/filesystem": "^2.0.5|^3.0",
+                "symfony/process": "^2.1|^3.0"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "guzzle/guzzle": "~3.0",
+                "phpunit/phpunit": "^4.0|^5.0",
+                "symfony/finder": "^2.0.5|^3.0"
+            },
+            "suggest": {
+                "ext-zip": "To use the ZipExtensionAdapter",
+                "guzzle/guzzle": "To use the GuzzleTeleporter"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Alchemy\\Zippy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alchemy",
+                    "email": "dev.team@alchemy.fr",
+                    "homepage": "http://www.alchemy.fr/"
+                }
+            ],
+            "description": "Zippy, the archive manager companion",
+            "keywords": [
+                "bzip",
+                "compression",
+                "tar",
+                "zip"
+            ],
+            "time": "2016-02-15 22:46:40"
+        },
         {
             "name": "dflydev/dot-access-configuration",
             "version": "v1.0.1",
@@ -174,6 +236,72 @@
             "time": "2012-10-28 21:08:28"
         },
         {
+            "name": "doctrine/collections",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2015-04-14 22:21:58"
+        },
+        {
             "name": "drupal/console-core",
             "version": "v1.0.0-rc8",
             "source": {
@@ -307,6 +435,218 @@
             "time": "2016-11-05 06:21:34"
         },
         {
+            "name": "gabordemooij/redbean",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gabordemooij/redbean.git",
+                "reference": "1c7ec69850e9f7966ff7feb87b01d8f43a9753d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gabordemooij/redbean/zipball/1c7ec69850e9f7966ff7feb87b01d8f43a9753d3",
+                "reference": "1c7ec69850e9f7966ff7feb87b01d8f43a9753d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RedBeanPHP\\": "RedBeanPHP"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "New BSD and GPLv2"
+            ],
+            "authors": [
+                {
+                    "name": "Gabor de Mooij",
+                    "email": "gabor@redbeanphp.com",
+                    "homepage": "http://redbeanphp.com"
+                }
+            ],
+            "description": "RedBeanPHP ORM",
+            "homepage": "http://redbeanphp.com/",
+            "keywords": [
+                "orm"
+            ],
+            "time": "2016-10-03 21:25:17"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "reference": "ebf29dee597f02f09f4d5bbecc68230ea9b08f60",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2016-10-08 15:01:37"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-05-18 16:56:05"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2016-06-24 23:00:38"
+        },
+        {
             "name": "padraic/humbug_get_contents",
             "version": "1.0.4",
             "source": {
@@ -414,6 +754,56 @@
                 "update"
             ],
             "time": "2016-01-05 23:08:01"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06 14:39:51"
         },
         {
             "name": "stecman/symfony-console-completion",
@@ -635,6 +1025,62 @@
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
             "time": "2016-09-06 23:19:39"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v2.8.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "a94f3fe6f179d6453e5ed8188cf4bfdf933d85f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/a94f3fe6f179d6453e5ed8188cf4bfdf933d85f4",
+                "reference": "a94f3fe6f179d6453e5ed8188cf4bfdf933d85f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "~2.8|~3.0.0"
+            },
+            "suggest": {
+                "symfony/css-selector": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DomCrawler Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-10-18 15:35:45"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/services.yml
+++ b/services.yml
@@ -7,3 +7,8 @@ services:
     class: Drupal\Console\Command\Self\UpdateCommand
     tags:
       - { name: drupal.command }
+  console.site_new:
+    class: Drupal\Console\Command\Site\NewCommand
+    arguments: ['@console.shell_process']
+    tags:
+      - { name: drupal.command }

--- a/src/Command/Shared/CoreDownloadTrait.php
+++ b/src/Command/Shared/CoreDownloadTrait.php
@@ -32,29 +32,30 @@ trait CoreDownloadTrait
         $commandKey = str_replace(':', '.', $this->getName());
 
         $io->comment(
-            sprintf(
-                $this->trans('commands.'.$commandKey.'.messages.downloading'),
-                $project,
-                $version
-            )
+          sprintf(
+            $this->trans('commands.'.$commandKey.'.messages.downloading'),
+            $project,
+            $version
+          )
         );
 
         try {
             $destination = $this->downloadCoreRelease(
-                $version
+              $version
             );
 
-            $projectPath = tempnam(sys_get_temp_dir(), 'drupal_');
+            $projectPath = tempnam(sys_get_temp_dir(), $project.'_');
             unlink($projectPath);
 
             if (!file_exists($projectPath)) {
                 if (!mkdir($projectPath, 0777, true)) {
                     $io->error(
-                        sprintf(
-                            $this->trans('commands.'.$commandKey.'.messages.error-creating-folder'),
-                            $projectPath
-                        )
+                      sprintf(
+                        $this->trans('commands.'.$commandKey.'.messages.error-creating-folder'),
+                        $projectPath
+                      )
                     );
+
                     return null;
                 }
             }
@@ -64,10 +65,10 @@ trait CoreDownloadTrait
                 $container = AdapterContainer::load();
                 $container['Drupal\\Console\\Zippy\\Adapter\\TarGzGNUTarForWindowsAdapter'] = function ($container) {
                     return TarGzGNUTarForWindowsAdapter::newInstance(
-                        $container['executable-finder'],
-                        $container['resource-manager'],
-                        $container['gnu-tar.inflator'],
-                        $container['gnu-tar.deflator']
+                      $container['executable-finder'],
+                      $container['resource-manager'],
+                      $container['gnu-tar.inflator'],
+                      $container['gnu-tar.deflator']
                     );
                 };
                 $zippy->addStrategy(new TarGzFileForWindowsStrategy($container));
@@ -87,8 +88,8 @@ trait CoreDownloadTrait
 
     /**
      * @param \Drupal\Console\Style\DrupalStyle $io
-     * @param bool                              $latest
-     * @param bool                              $stable
+     * @param bool $latest
+     * @param bool $stable
      * @return string
      */
     public function releasesQuestion(DrupalStyle $io, $latest = false, $stable = false)
@@ -96,20 +97,20 @@ trait CoreDownloadTrait
         $commandKey = str_replace(':', '.', $this->getName());
 
         $io->comment(
-            sprintf(
-                $this->trans('commands.'.$commandKey.'.messages.getting-releases'),
-                'drupal'
-            )
+          sprintf(
+            $this->trans('commands.'.$commandKey.'.messages.getting-releases'),
+            'drupal'
+          )
         );
 
-        $releases = $this->getCoreReleases($latest?1:15, $stable);
+        $releases = $this->getCoreReleases($latest ? 1 : 15, $stable);
 
         if (!$releases) {
             $io->error(
-                sprintf(
-                    $this->trans('commands.'.$commandKey.'.messages.no-releases'),
-                    'drupal'
-                )
+              sprintf(
+                $this->trans('commands.'.$commandKey.'.messages.no-releases'),
+                'drupal'
+              )
             );
 
             return null;
@@ -120,8 +121,8 @@ trait CoreDownloadTrait
         }
 
         $version = $io->choice(
-            $this->trans('commands.'.$commandKey.'.messages.select-release'),
-            $releases
+          $this->trans('commands.'.$commandKey.'.messages.select-release'),
+          $releases
         );
 
         return $version;
@@ -154,7 +155,7 @@ trait CoreDownloadTrait
             $releases[] = $element->nodeValue;
         }
 
-        if (count($releases)>$limit) {
+        if (count($releases) > $limit) {
             array_splice($releases, $limit);
         }
 
@@ -163,7 +164,7 @@ trait CoreDownloadTrait
 
     /**
      * @param $release
-     * @param null    $destination
+     * @param null $destination
      * @return null|string
      */
     public function downloadCoreRelease($release, $destination = null)

--- a/src/Command/Shared/CoreDownloadTrait.php
+++ b/src/Command/Shared/CoreDownloadTrait.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Command\Shared\CoreDownloadTrait.
+ */
+
+namespace Drupal\Console\Command\Shared;
+
+use Drupal\Console\Style\DrupalStyle;
+use Drupal\Console\Zippy\Adapter\TarGzGNUTarForWindowsAdapter;
+use Drupal\Console\Zippy\FileStrategy\TarGzFileForWindowsStrategy;
+use Alchemy\Zippy\Zippy;
+use Alchemy\Zippy\Adapter\AdapterContainer;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class CoreDownloadTrait
+ * @package Drupal\Console\Command\Shared
+ */
+trait CoreDownloadTrait
+{
+    /**
+     * @param \Drupal\Console\Style\DrupalStyle $io
+     * @param $version
+     *
+     * @return string
+     */
+    public function downloadCore(DrupalStyle $io, $version)
+    {
+        $project = 'drupal';
+        $commandKey = str_replace(':', '.', $this->getName());
+
+        $io->comment(
+            sprintf(
+                $this->trans('commands.'.$commandKey.'.messages.downloading'),
+                $project,
+                $version
+            )
+        );
+
+        try {
+            $destination = $this->downloadCoreRelease(
+                $version
+            );
+
+            $projectPath = tempnam(sys_get_temp_dir(), 'drupal_');
+            unlink($projectPath);
+
+            if (!file_exists($projectPath)) {
+                if (!mkdir($projectPath, 0777, true)) {
+                    $io->error(
+                        sprintf(
+                            $this->trans('commands.'.$commandKey.'.messages.error-creating-folder'),
+                            $projectPath
+                        )
+                    );
+                    return null;
+                }
+            }
+
+            $zippy = Zippy::load();
+            if (PHP_OS === "WIN32" || PHP_OS === "WINNT") {
+                $container = AdapterContainer::load();
+                $container['Drupal\\Console\\Zippy\\Adapter\\TarGzGNUTarForWindowsAdapter'] = function ($container) {
+                    return TarGzGNUTarForWindowsAdapter::newInstance(
+                        $container['executable-finder'],
+                        $container['resource-manager'],
+                        $container['gnu-tar.inflator'],
+                        $container['gnu-tar.deflator']
+                    );
+                };
+                $zippy->addStrategy(new TarGzFileForWindowsStrategy($container));
+            }
+            $archive = $zippy->open($destination);
+            $archive->extract(getenv('MSYSTEM') ? null : $projectPath);
+
+            unlink($destination);
+        } catch (\Exception $e) {
+            $io->error($e->getMessage());
+
+            return null;
+        }
+
+        return $projectPath;
+    }
+
+    /**
+     * @param \Drupal\Console\Style\DrupalStyle $io
+     * @param bool                              $latest
+     * @param bool                              $stable
+     * @return string
+     */
+    public function releasesQuestion(DrupalStyle $io, $latest = false, $stable = false)
+    {
+        $commandKey = str_replace(':', '.', $this->getName());
+
+        $io->comment(
+            sprintf(
+                $this->trans('commands.'.$commandKey.'.messages.getting-releases'),
+                'drupal'
+            )
+        );
+
+        $releases = $this->getCoreReleases($latest?1:15, $stable);
+
+        if (!$releases) {
+            $io->error(
+                sprintf(
+                    $this->trans('commands.'.$commandKey.'.messages.no-releases'),
+                    'drupal'
+                )
+            );
+
+            return null;
+        }
+
+        if ($latest) {
+            return $releases[0];
+        }
+
+        $version = $io->choice(
+            $this->trans('commands.'.$commandKey.'.messages.select-release'),
+            $releases
+        );
+
+        return $version;
+    }
+
+    /**
+     * @param $limit
+     * @param $stable
+     * @return array
+     * @throws \Exception
+     */
+    public function getCoreReleases($limit = 10, $stable = false)
+    {
+        $projectPageResponse = $this->httpClient->getUrlAsString(
+          'https://updates.drupal.org/release-history/drupal/8.x'
+        );
+
+        if ($projectPageResponse->getStatusCode() != 200) {
+            throw new \Exception('Invalid path.');
+        }
+
+        $releases = [];
+        $crawler = new Crawler($projectPageResponse->getBody()->getContents());
+        $filter = './project/releases/release/version';
+        if ($stable) {
+            $filter = './project/releases/release[not(version_extra)]/version';
+        }
+
+        foreach ($crawler->filterXPath($filter) as $element) {
+            $releases[] = $element->nodeValue;
+        }
+
+        if (count($releases)>$limit) {
+            array_splice($releases, $limit);
+        }
+
+        return $releases;
+    }
+
+    /**
+     * @param $release
+     * @param null    $destination
+     * @return null|string
+     */
+    public function downloadCoreRelease($release, $destination = null)
+    {
+        if (!$release) {
+            $releases = $this->getCoreReleases(1);
+            $release = current($releases);
+        }
+
+        if (!$destination) {
+            $destination = sprintf(
+              '%s/%s.tar.gz',
+              sys_get_temp_dir(),
+              'drupal'
+            );
+        }
+
+        $releaseFilePath = sprintf(
+          'https://ftp.drupal.org/files/projects/%s-%s.tar.gz',
+          'drupal',
+          $release
+        );
+
+        if ($this->downloadFile($releaseFilePath, $destination)) {
+            return $destination;
+        }
+
+        return null;
+    }
+
+    public function downloadFile($url, $destination)
+    {
+        $this->httpClient->get($url, array('sink' => $destination));
+
+        return file_exists($destination);
+    }
+}

--- a/src/Command/Site/NewCommand.php
+++ b/src/Command/Site/NewCommand.php
@@ -206,10 +206,10 @@ class NewCommand extends Command
         $io = new DrupalStyle($input, $output);
 
         $directory = $input->getArgument('directory');
-        $version   = $input->getArgument('version');
-        $latest    = $input->getOption('latest');
-        $unstable  = $input->getOption('unstable');
-        $composer  = $input->getOption('composer');
+        $version = $input->getArgument('version');
+        $latest = $input->getOption('latest');
+        $unstable = $input->getOption('unstable');
+        $composer = $input->getOption('composer');
 
         if (!$directory) {
             $directory = $io->ask(

--- a/src/Command/Site/NewCommand.php
+++ b/src/Command/Site/NewCommand.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Console\Command\Site\NewCommand.
+ */
+
+namespace Drupal\Console\Command\Site;
+
+use Drupal\Console\Utils\ShellProcess;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
+use Symfony\Component\Console\Command\Command;
+use Drupal\Console\Command\Shared\CommandTrait;
+use Drupal\Console\Style\DrupalStyle;
+use Drupal\Console\Command\Shared\CoreDownloadTrait;
+
+/**
+ * Class NewCommand
+ * @package Drupal\Console\Command\Site
+ */
+class NewCommand extends Command
+{
+    use CoreDownloadTrait;
+    use CommandTrait;
+
+    /** @var ShellProcess */
+    protected $shellProcess;
+
+    /** @var \GuzzleHttp\Client */
+    protected $httpClient;
+
+    /**
+     * UpdateCommand constructor.
+     * @param ShellProcess $shellProcess
+     */
+    public function __construct(
+      ShellProcess $shellProcess
+    ) {
+        $this->shellProcess = $shellProcess;
+        $this->httpClient = new Client();
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+          ->setName('site:new')
+          ->setDescription($this->trans('commands.site.new.description'))
+          ->addArgument(
+            'directory',
+            InputArgument::REQUIRED,
+            $this->trans('commands.site.new.arguments.directory')
+          )
+          ->addArgument(
+            'version',
+            InputArgument::OPTIONAL,
+            $this->trans('commands.site.new.arguments.version')
+          )
+          ->addOption(
+            'latest',
+            '',
+            InputOption::VALUE_NONE,
+            $this->trans('commands.site.new.options.latest')
+          )
+          ->addOption(
+            'composer',
+            '',
+            InputOption::VALUE_NONE,
+            $this->trans('commands.site.new.options.composer')
+          )
+          ->addOption(
+            'unstable',
+            '',
+            InputOption::VALUE_NONE,
+            $this->trans('commands.site.new.options.unstable')
+          );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $directory = $input->getArgument('directory');
+        $version = $input->getArgument('version');
+        $latest = $input->getOption('latest');
+        $unstable = $input->getOption('unstable');
+        $composer = $input->getOption('composer');
+
+        if (!$directory) {
+            $io->error(
+              $this->trans('commands.site.new.messages.missing-directory')
+            );
+
+            return 1;
+        }
+
+        if ($composer) {
+            if (!$version) {
+                $version = '8.x-dev';
+            }
+
+            $io->newLine();
+            $io->comment(
+              sprintf(
+                $this->trans('commands.site.new.messages.executing'),
+                'drupal',
+                $version
+              )
+            );
+
+            $command = sprintf(
+              'composer create-project %s:%s %s --no-interaction',
+              'drupal-composer/drupal-project',
+              $version,
+              $directory
+            );
+
+            $io->commentBlock($command);
+
+            if ($this->shellProcess->exec($command)) {
+                $io->success(
+                  sprintf(
+                    $this->trans('commands.site.new.messages.composer'),
+                    $version,
+                    $directory
+                  )
+                );
+
+                return 0;
+            } else {
+                return 1;
+            }
+        }
+
+        if (!$version && $latest) {
+            $version = current(
+              $this->getCoreReleases(1, !$unstable)
+            );
+        }
+
+        if (!$version) {
+            $io->error('Missing version');
+
+            return 1;
+        }
+
+        $projectPath = $this->downloadCore($io, $version);
+        $downloadPath = sprintf('%s/drupal-%s', $projectPath, $version);
+
+        if ($this->isAbsolutePath($directory)) {
+            $copyPath = $directory;
+        } else {
+            $copyPath = sprintf('%s%s', $projectPath, $directory);
+        }
+
+        try {
+            $fileSystem = new Filesystem();
+            $fileSystem->rename($downloadPath, $copyPath);
+        } catch (IOExceptionInterface $e) {
+            $io->commentBlock(
+              sprintf(
+                $this->trans('commands.site.new.messages.downloaded'),
+                $version,
+                $downloadPath
+              )
+            );
+
+            $io->error(
+              sprintf(
+                $this->trans('commands.site.new.messages.error-copying'),
+                $e->getPath()
+              )
+            );
+
+            return 1;
+        }
+
+        $io->success(
+          sprintf(
+            $this->trans('commands.site.new.messages.downloaded'),
+            $version,
+            $copyPath
+          )
+        );
+
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $io = new DrupalStyle($input, $output);
+
+        $directory = $input->getArgument('directory');
+        $version   = $input->getArgument('version');
+        $latest    = $input->getOption('latest');
+        $unstable  = $input->getOption('unstable');
+        $composer  = $input->getOption('composer');
+
+        if (!$directory) {
+            $directory = $io->ask(
+              $this->trans('commands.site.new.questions.directory')
+            );
+            $input->setArgument('directory', $directory);
+        }
+
+        if ($composer) {
+            $input->setArgument('version', '8.x-dev');
+
+            return 0;
+        }
+
+        if (!$version && $latest) {
+            $version = current(
+              $this->getCoreReleases(1, true)
+            );
+        }
+
+        if (!$version) {
+            $version = $this->releasesQuestion($io, false, !$unstable);
+        }
+
+        $input->setArgument('version', $version);
+
+        return 0;
+    }
+
+    protected function isAbsolutePath($path)
+    {
+        return $path[0] === DIRECTORY_SEPARATOR || preg_match('~\A[A-Z]:(?![^/\\\\])~i', $path) > 0;
+    }
+}

--- a/src/Zippy/Adapter/TarGzGNUTarForWindowsAdapter.php
+++ b/src/Zippy/Adapter/TarGzGNUTarForWindowsAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Zippy\Adapter\TarGzGNUTarForWindowsAdapter.
+ */
+
+namespace Drupal\Console\Zippy\Adapter;
+
+use Alchemy\Zippy\Adapter\GNUTar\TarGzGNUTarAdapter;
+use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Exception\NotSupportedException;
+
+/**
+ * Class TarGzGNUTarForWindowsAdapter
+ * @package Drupal\Console\Zippy\Adapter
+ */
+class TarGzGNUTarForWindowsAdapter extends TarGzGNUTarAdapter
+{
+    /**
+     * @inheritdoc
+     */
+    protected function doAdd(ResourceInterface $resource, $files, $recursive)
+    {
+        throw new NotSupportedException('Updating a compressed tar archive is not supported.');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getLocalOptions()
+    {
+        return array_merge(parent::getLocalOptions(), array('--force-local'));
+    }
+}

--- a/src/Zippy/FileStrategy/TarGzFileForWindowsStrategy.php
+++ b/src/Zippy/FileStrategy/TarGzFileForWindowsStrategy.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Contains Drupal\Console\Zippy\Strategy\ProjectDownloadTrait.
+ */
+
+namespace Drupal\Console\Zippy\FileStrategy;
+
+use Alchemy\Zippy\FileStrategy\AbstractFileStrategy;
+
+/**
+ * Class TarGzFileForWindowsStrategy
+ * @package Drupal\Console\Zippy/Strategy
+ */
+class TarGzFileForWindowsStrategy extends AbstractFileStrategy
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getServiceNames()
+    {
+        return array(
+            'Drupal\\Console\\Zippy\\Adapter\\TarGzGNUTarForWindowsAdapter'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFileExtension()
+    {
+        return 'tar.gz';
+    }
+}


### PR DESCRIPTION
Move `Site\NewCommand` from `DrupalConsole` repository to this one.
Changes has been made too on `drupal-console-core` and `DrupalConsole`.

This PR needs review essentially on 3 points:

- (file NewCommand, line 46): `http_client` is not injected because I can't find how to do it on this repo, seems to be missing,
- (files TarGzGNUTarForWindowsAdapter.php and TarGzFileForWindowsStrategy.php): those files has been copied/pasted from `DrupalConsole` as it. May be could mutualized on `drupal-console-core`.
- (file CoreDownloadTrait, line 47-48): I made a quick code to create a new folder name, I let you clean this part of code if you think it is too awful.