### PR TITLE
Fix Launcher on Windows

### DIFF
--- a/src/Utils/Launcher.php
+++ b/src/Utils/Launcher.php
@@ -16,13 +16,8 @@ class Launcher
     {
         chdir($root);
 
-        /* drupal symlink executable */
-        $drupal = $root.'/vendor/bin/drupal';
-
-        if (!file_exists($drupal)) {
-            /* drupal symlink does not work, try full path */
-            $drupal = $root.'/vendor/drupal/console/bin/drupal';
-        }
+        /* drupal executable */
+        $drupal = $root.'/vendor/drupal/console/bin/drupal';
 
         if (!file_exists($drupal)) {
             return false;


### PR DESCRIPTION
Start with drupal executable.
Don't assume composer always creates a symlink.