### PR TITLE
Use Colors:NONE instead of Colors:WHITE to revert console colors. Fixes #103

### DIFF
--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -48,10 +48,10 @@ foreach ($argv as $value) {
     }
 }
 if ($showVersion || $debug) {
-    echo Colors::LIGHT_GREEN . 'Drupal Console Launcher' . Colors::WHITE . ' version ' . Colors::YELLOW . $version . Colors::WHITE . PHP_EOL;
+    echo Colors::LIGHT_GREEN . 'Drupal Console Launcher' . Colors::NONE . ' version ' . Colors::YELLOW . $version . Colors::NONE . PHP_EOL;
 }
 if ($debug) {
-    echo Colors::LIGHT_GREEN . 'Path: ' . Colors::YELLOW . $argv[0] . Colors::WHITE . PHP_EOL . PHP_EOL;
+    echo Colors::LIGHT_GREEN . 'Path: ' . Colors::YELLOW . $argv[0] . Colors::NONE . PHP_EOL . PHP_EOL;
 }
 
 $drupalFinder = new DrupalFinder();

--- a/src/Utils/Colors.php
+++ b/src/Utils/Colors.php
@@ -20,6 +20,7 @@ class Colors
     const YELLOW = "\033[1;33m";
     const LIGHT_GRAY = "\033[0;37m";
     const WHITE = "\033[1;37m";
+    const NONE = "\033[0m";
 
     const BG_BLACK = "\033[40m";
     const BG_RED = "\033[41m";


### PR DESCRIPTION
This is a fix for #103 