### PR TITLE
Propagate the local launcher's exitcode, for proper error handling.

### DIFF
--- a/bin/drupal.php
+++ b/bin/drupal.php
@@ -104,9 +104,9 @@ if ($debug) {
 
 if ($isValidDrupal) {
     $launcher = $container->get('console.launcher_local');
-    $launch = $launcher->launch($drupalFinder);
+    $exitcode = $launcher->launch($drupalFinder);
 
-    if (!$launch) {
+    if ($exitcode === FALSE) {
         $message = sprintf(
             $translator->trans('application.site.errors.not-installed'),
             PHP_EOL . $drupalFinder->getComposerRoot()
@@ -124,7 +124,7 @@ if ($isValidDrupal) {
         exit(1);
     }
 
-    exit(0);
+    exit($exitcode);
 }
 
 $argvInputReader->restoreOriginalArgvValues();

--- a/src/Utils/LauncherLocal.php
+++ b/src/Utils/LauncherLocal.php
@@ -34,8 +34,11 @@ class LauncherLocal extends Launcher
             $drupalFinder->getComposerRoot()
         );
 
-        proc_close($process);
+        // If process was successful, we'll return it's exitcode to propagate
+        if ($process) {
+          return proc_close($process);
+        }
 
-        return true;
+        return false;
     }
 }


### PR DESCRIPTION
Should fix hechoendrupal/drupal-console#3758