### PR TITLE
Updated installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Drupal Console Launcher 
+# Drupal Console Launcher
 
 DrupalConsole global executable aka Launcher.
 
@@ -10,7 +10,7 @@ For example, if you have Drupal root in the `web` or `docroot` directory, and a 
 
 ## Installing Drupal Console Launcher
 ```
-curl https://drupalconsole.com/installer -L -o drupal.phar
-mv drupal.phar /usr/local/bin/drupal
-chmod +x /usr/local/bin/drupal
+curl -L https://drupalconsole.com/installer > drupal.phar
+chmod +x drupal.phar
+sudo mv drupal.phar /usr/local/bin/drupal
 ```


### PR DESCRIPTION
The `-o` option for curl is not available on all systems. I believe redirection would be more convenient. The second change was adding `sudo` to `mv` since `/usr/local/bin/` is not writable by normal user. The last change is making it executable before moving it to avoid having to execute with `sudo` twice.